### PR TITLE
Get rid of blacklisting logic

### DIFF
--- a/R/check-function-result.R
+++ b/R/check-function-result.R
@@ -53,7 +53,7 @@ check_call_result <- function(state, error_msg, append, type = c("function", "op
   CallResultState <- switch(type, `function` = FunctionResultState, operator = OperationResultState)
   
   solution_call <- state$get("solution_call")
-  student_calls <- state$get("student_calls")
+  student_call <- state$get("student_call")
   student_env <- state$get("student_env")
   solution_env <- state$get("solution_env")
   
@@ -61,47 +61,20 @@ check_call_result <- function(state, error_msg, append, type = c("function", "op
   callresult_state$add_details(type = type,
                                case = "result_runs",
                                message = error_msg,
+                               pd = student_call$pd,
                                append = append)
   
   sol_res <- tryCatch(base::eval(solution_call$call, envir = solution_env), error = function(e) e)
   if (inherits(sol_res, 'error')) {
     stop(sprintf("Running %s gave an error: %s", deparse(solution_call$call), sol_res$message))
   }
-  solution_call$result <- sol_res
+
+  stud_res <- tryCatch(base::eval(student_call$call, envir = student_env), error = function(e) e)
   
-  res <- logical(length(student_calls))
-  details <- NULL
-  for (i in seq_along(student_calls)) {
-    student_call <- student_calls[[i]]
-    if (isTRUE(is.na(student_call))) next
-    
-    # If no hits, use details of the first try
-    if (is.null(details)) {
-      callresult_state$set_details(pd = student_call$pd)
-      details <- callresult_state$details
-    }
-    
-    stud_res <- tryCatch(base::eval(student_call$call, envir = student_env), error = function(e) e)
-    
-    # Check if the call passed
-    if (!inherits(stud_res, 'error')) {
-      callresult_state$log(index = i, arg = 'none', success = TRUE)
-      student_calls[[i]]$result <- stud_res
-      res[i] <- TRUE
-    } else {
-      callresult_state$log(index = i, arg = 'none', success = FALSE)
-    }
-  }
+  check_that(is_false(inherits(stud_res, 'error')), feedback = callresult_state$details)
   
-  if (is.null(details)) {
-    details <- callresult_state$details
-  }
-  check_that(is_gte(sum(res), 1), feedback = details)
-  
-  student_calls[!res] <- NA
-  callresult_state$set(student_calls = student_calls,
-                       solution_call = solution_call)
-  
+  callresult_state$set(student_call_result = stud_res,
+                       solution_call_result = sol_res)
   callresult_state$set_details(case = "result_correct",
                                message = NULL)
   return(callresult_state)
@@ -111,49 +84,22 @@ check_call_result <- function(state, error_msg, append, type = c("function", "op
 
 check_call_result_equal <- function(state, eq_condition, eq_fun, incorrect_msg, append, type = c("function", "operator")) {
   type <- match.arg(type)
-  solution_call <- state$get("solution_call")
-  student_calls <- state$get("student_calls")
+  sol_res <- state$get("solution_call_result")
+  stud_res <- state$get("student_call_result")
   state$add_details(type = type,
                     case = "result_equal",
                     eq_condition = eq_condition,
                     message = incorrect_msg,
+                    student = stud_res,
+                    solution = sol_res,
                     append = append)
-  
-  sol_res <- solution_call$result
   
   if (is.null(eq_fun)) {
     eq_fun <- function(x, y) is_equal(x, y, eq_condition)
   }
 
-  res <- logical(length(student_calls))
-  details <- NULL
-  for (i in seq_along(student_calls)) {
-    student_call <- student_calls[[i]]
-    if (isTRUE(is.na(student_call))) next
-    stud_res <- student_call$result
-    
-    # If no hits, use details of the first try
-    if (is.null(details)) {
-      state$set_details(student = stud_res,
-                        solution = sol_res,
-                        pd = student_call$pd)
-      details <- state$details
-    }
-    
-    # Check if the function arguments correspond
-    if (eq_fun(stud_res, sol_res)) {
-      state$log(index = i, success = TRUE)
-      res[i] <- TRUE
-    } else {
-      state$log(index = i, success = FALSE)
-    }
-  }
+  check_that(expect_true(eq_fun(stud_res, sol_res)), feedback = state$details)
   
-  if (is.null(details)) {
-    details <- state$details
-  }
-  
-  check_that(is_gte(sum(res), 1), feedback = details)
   return(state)
 }
 

--- a/R/state.R
+++ b/R/state.R
@@ -102,23 +102,7 @@ State <- R6::R6Class("State",
                        solution_pd = NULL,
                        solution_env = NULL,
                        output_list = NULL,
-                       test_env = NULL,
-                       # fun usage
-                       fun_usage = NULL,
-                       active_name = NULL,
-                       active_sol_index = NULL,
-                       active_arg = NULL,
-                       blacklist = list(),
-                       set_used = function(name, sol_index, stud_index) {
-                         add <- list(name = name,
-                                     stud_index = stud_index,
-                                     sol_index = sol_index)
-                         if (any(sapply(private$blacklist, function(x) isTRUE(try(all.equal(add, x)))))) {
-                           # don't add
-                         } else {
-                           private$blacklist = c(private$blacklist, list(add))
-                         }
-                       }
+                       test_env = NULL
                      )
 )
 
@@ -175,15 +159,16 @@ ChildState <- R6::R6Class("ChildState", inherit = State,
 )
 
 
-CallState <- R6::R6Class("CallState", inherit = ChildState, private = list(student_calls = NULL, solution_call = NULL))
+CallState <- R6::R6Class("CallState", inherit = ChildState, private = list(student_call = NULL, solution_call = NULL))
 FunctionState <- R6::R6Class("FunctionState", inherit = CallState)
 OperationState <- R6::R6Class("OperationState", inherit = CallState)
 
-CallResultState <- R6::R6Class("CallResultState", inherit = CallState)
+CallResultState <- R6::R6Class("CallResultState", inherit = CallState, private = list(student_call_result = NULL,
+                                                                                      solution_call_result = NULL))
 FunctionResultState <- R6::R6Class("FunctionResultState", inherit = CallResultState)
 OperationResultState <- R6::R6Class("OperationResultState", inherit = CallResultState)
 
-ArgumentState <- R6::R6Class("ArgumentState", inherit = ChildState, private = list(student_args = NULL, solution_arg = NULL))
+ArgumentState <- R6::R6Class("ArgumentState", inherit = ChildState, private = list(student_arg = NULL, solution_arg = NULL))
 
 ObjectState <- R6::R6Class("ObjectState", inherit = ChildState, private = list(name = NULL, student_object = NULL, solution_object = NULL))
 ObjectColumnState <- R6::R6Class("ObjectColumnState", inherit = ObjectState)

--- a/tests/testthat/test-check-function-result.R
+++ b/tests/testthat/test-check-function-result.R
@@ -19,6 +19,7 @@ test_that("test call result - functions - step by step", {
 
   lst$DC_CODE <- "mtcars %>% summarise(min = min(mpg), max = max(mpg))"
   output <- test_it(lst)
+  fails(output)
   fb_contains(output, "Check your call of <code>summarise()</code>")
   fb_contains(output, "Running it again doesn")
 
@@ -89,24 +90,24 @@ test_that("test call result - functions - backwards compatbile - custom", {
   lst$DC_PEC <- "library(dplyr)"
   lst$DC_SOLUTION <- "mtcars %>% summarise(avg = mean(mpg), max = max(mpg))"
   lst$DC_SCT <- "test_function_result('summarise', not_called_msg = 'notcalled', error_msg = 'error', incorrect_msg = 'incorrect')"
-  
+
   lst$DC_CODE <- "mtcars %>% filter(mpg > 20)"
   output <- test_it(lst)
   fails(output)
   fb_contains(output, "Notcalled")
-  
+
   lst$DC_CODE <- "mtcars %>% summarise(min = min(mpg), max = max(non_existing))"
   output <- test_it(lst)
   fails(output)
   fb_excludes(output, "Check your call of <code>summarise()</code>")
   fb_contains(output, "Error")
-  
+
   lst$DC_CODE <- "mtcars %>% summarise(min = min(mpg), max = max(mpg))"
   output <- test_it(lst)
   fails(output)
   fb_excludes(output, "Check your call of <code>summarise()</code>")
   fb_contains(output, "Incorrect")
-  
+
   lst$DC_CODE <- lst$DC_SOLUTION
   output <- test_it(lst)
   passes(output)
@@ -117,7 +118,7 @@ test_that("test call result - functions - errs appropriately", {
   lst$DC_PEC <- "library(dplyr)"
   lst$DC_SOLUTION <- "mtcars %>% summarise(avg = mean(mpg), max = max(mpg))"
   lst$DC_SCT <- "test_function_result('mutate')"
-  
+
   expect_error(test_it(lst))
 })
 
@@ -150,9 +151,11 @@ test_that("test call result - functions - indexing", {
   output <- test_it(lst)
   passes(output)
 
+  # no blacklisting anymore, so this shouldn't pass
   lst$DC_CODE <- "mtcars %>% summarise(min = min(mpg), sd = sd(mpg))\nmtcars %>% summarise(avg = mean(mpg), max = max(mpg))"
   output <- test_it(lst)
-  passes(output)
+  fails(output)
+  line_info(output, 1, 1)
 })
 
 test_that("test call result - custom eq_fun", {
@@ -173,7 +176,7 @@ test_that("test call result - custom eq_fun", {
     if (ex$correct) passes(output) else fails(output)
   }
 })
-
+ 
 context("check operator result")
 
 test_that("check_operator - step by step", {
@@ -231,17 +234,14 @@ test_that("check_operator - arithmetic/relational/logical", {
   output <- test_it(lst)
   passes(output)
 
-  lst$DC_CODE <- "1 + 3\n7 + 8"
-  output <- test_it(lst)
-  passes(output)
-
   lst$DC_CODE <- "6 + 9"
   output <- test_it(lst)
   passes(output)
-
-  lst$DC_CODE <- "1 + 3\n6 + 9"
+  
+  # no blacklisting anymore, this fails
+  lst$DC_CODE <- "1 + 3\n7 + 8"
   output <- test_it(lst)
-  passes(output)
+  fails(output)
 
   lst$DC_CODE <- "mean(7 + 8)"
   output <- test_it(lst)
@@ -294,9 +294,10 @@ test_that("check_operator - index", {
   output <- test_it(lst)
   passes(output)
 
+  # no blacklisting, this should fail
   lst$DC_CODE <- "10 + 20\n4 + 5"
   output <- test_it(lst)
-  passes(output)
+  fails(output)
 
   lst$DC_CODE <- ""
   output <- test_it(lst)
@@ -324,5 +325,3 @@ test_that("check_operator - errs correctly", {
   lst$DC_SOLUTION <- ""
   expect_error(test_it(lst))
 })
-
-


### PR DESCRIPTION
- Before, when testing multiple function calls, the student submission would
  be accepted if they were swapped around. This gave unexpected behavior in
  some cases.
- Supporting this made the internal testwhat logic very tricky
- All of this has been cleaned up and tests have been updated accordingly
- checking function calls is now the same as in pythonwhat
- In the meantime, also fix a bug reported by @richierocks

Closes #173
Closes #206