### PR TITLE
Use envir_prep for exercise checking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,3 +41,4 @@ Authors@R: c(
     )
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
+Encoding: UTF-8

--- a/R/test-exercise.R
+++ b/R/test-exercise.R
@@ -76,12 +76,16 @@ test_exercise <- function(sct,
 #' Run SCT until it fails
 #'
 #' @param code the SCT script to run as an expression
+#' @param envir environment in which to execute the SCT script
 #'
 #' @export
-run_until_fail <- function(code) {
+run_until_fail <- function(code, envir = NULL) {
   tryCatch({
+    if (is.null(envir)) {
+      envir <- tw$get("state")$get("test_env")
+    }
     # Run the SCT
-    eval(code, envir = tw$get("state")$get("test_env"))
+    eval(code, envir = envir)
     # If it got here, the SCT passed
     return(list(correct = TRUE, message = tw$get("success_msg")))
   }, sct_failure = function(e) {

--- a/R/utils-learnr.R
+++ b/R/utils-learnr.R
@@ -34,8 +34,8 @@ testwhat_learnr <- function(label = NULL,
                             envir_result = NULL,
                             evaluate_result = NULL,
                             ...) {
-  
-  ######### START COPY FROM grade_learnr ##################
+
+  ######### START COPY FROM gradethis ##################
   # Sometimes no user code is provided, but
   # that means there is nothing to check. Also,
   # you do not want to parse NULL
@@ -59,8 +59,8 @@ testwhat_learnr <- function(label = NULL,
       location = "append"
     ))
   }
-  ######### END COPY FROM grade_learnr ##################
-  
+  ######### END COPY FROM gradethis ##################
+
   setup_state(sol_code = solution_code,
               stu_code = user_code,
               sol_env = NULL,

--- a/R/utils-learnr.R
+++ b/R/utils-learnr.R
@@ -21,6 +21,7 @@
 #' @param envir_result 	The R environment after the execution of the chunk.
 #' @param evaluate_result The return value from the \code{evaluate::evaluate}
 #'   function.
+#' @param envir_prep A copy of the R environment before the execution of the exercise
 #' @param ... Unused (include for compatibility with parameters to be added in
 #'   the future)
 #'
@@ -33,6 +34,7 @@ testwhat_learnr <- function(label = NULL,
                             check_code = NULL,
                             envir_result = NULL,
                             evaluate_result = NULL,
+                            envir_prep = NULL,
                             ...) {
 
   ######### START COPY FROM gradethis ##################
@@ -47,7 +49,7 @@ testwhat_learnr <- function(label = NULL,
       location = "append"
     ))
   }
-  
+
   # Sometimes no solution is provided, but that
   # means there is nothing to check against. Also,
   # you do not want to parse NULL
@@ -66,8 +68,8 @@ testwhat_learnr <- function(label = NULL,
               sol_env = NULL,
               stu_env = envir_result,
               stu_result = evaluate_result)
-  
-  res <- run_until_fail(parse(text = check_code))
+
+  res <- run_until_fail(parse(text = check_code), envir = envir_prep)
   return(list(message = res$message,
               correct = res$correct,
               location = "append",

--- a/man/check_function.Rd
+++ b/man/check_function.Rd
@@ -22,8 +22,10 @@ check_arg(state, arg, arg_not_specified_msg = NULL, append = TRUE)
 \arguments{
 \item{state}{state to start from}
 
-\item{name}{name of the function/operator as a string, e.g. \code{"mean"} or
-\code{"+"}}
+\item{name}{name of the function/operator as a string, e.g. \code{"mean"},
+\code{"+"} or \code{"..."}; can also be used for positional access, e.g.
+\code{1} for the first argument and \code{"..1"} for the first item in
+\code{"..."}}
 
 \item{index}{integer that specifies which call of \code{name} in the
 solution code will be checked.}
@@ -34,7 +36,8 @@ call the function often enough.}
 \item{append}{Whether or not to append the feedback to feedback built in
 previous states}
 
-\item{arg}{name of argument to specify (for \code{check_arg})}
+\item{arg}{name or position of argument to specify
+... Arguments can be accessed using '..<INDEX>' (see example 4) (for \code{check_arg})}
 
 \item{arg_not_specified_msg}{custom message in case argument was not
 specified (for \code{check_arg})}
@@ -90,6 +93,16 @@ ex() \%>\% check_function("mean") \%>\% {
 
 # SCT
 ex() \%>\% check_operator("+") \%>\% check_result() \%>\% check_equal()
+}
+
+# Example 4: ... in check_args
+
+soln <- "std_dev <- purrr::compose(sqrt, var, .dir='forward')"
+state <- setup_state(soln, soln)
+state \%>\% check_function(., "compose") \%>\% {
+ check_arg(., '..1') \%>\% check_equal() # sqrt
+ check_arg(., '..2') \%>\% check_equal() # var
+ check_arg(., '.dir') \%>\% check_equal()
 }
 
 }

--- a/man/check_logic.Rd
+++ b/man/check_logic.Rd
@@ -66,7 +66,7 @@ x <- mean(-1:5)
 # Example SCT
 ex() \%>\% check_or(
   check_object(., 'a') \%>\% check_equal(),
-  check_object(., 'b') \%>\% checK-equal()
+  check_object(., 'b') \%>\% check-equal()
 )
 
 # Following submissions will all be accepted:

--- a/man/run_until_fail.Rd
+++ b/man/run_until_fail.Rd
@@ -4,10 +4,12 @@
 \alias{run_until_fail}
 \title{Run SCT until it fails}
 \usage{
-run_until_fail(code)
+run_until_fail(code, envir = NULL)
 }
 \arguments{
 \item{code}{the SCT script to run as an expression}
+
+\item{envir}{environment in which to execute the SCT script}
 }
 \description{
 Run SCT until it fails

--- a/man/testwhat_learnr.Rd
+++ b/man/testwhat_learnr.Rd
@@ -6,7 +6,7 @@
 \usage{
 testwhat_learnr(label = NULL, solution_code = NULL, user_code = NULL,
   check_code = NULL, envir_result = NULL, evaluate_result = NULL,
-  ...)
+  envir_prep = NULL, ...)
 }
 \arguments{
 \item{label}{Label for exercise chunk}
@@ -22,6 +22,8 @@ exercise.}
 
 \item{evaluate_result}{The return value from the \code{evaluate::evaluate}
 function.}
+
+\item{envir_prep}{A copy of the R environment before the execution of the exercise}
 
 \item{...}{Unused (include for compatibility with parameters to be added in
 the future)}


### PR DESCRIPTION
Fixes https://github.com/rstudio/learnr/issues/202

The next release of learnr (v`0.10.0`) will provide a copy of the environment before the user executed their code `envir_prep` to the exercise checker function (ex: `testwhat_learnr`). 

Using this environment, checking code will be able to find their setup code.

Disclaimers:
* I have not tested this. 
* I do not know if I have broken `run_until_fail`. 
* I would believe this would work with `learnr` v`0.9.2` and the next release of v`0.10.0`
* Existing users should not have to alter their code to get the expected behavior

cc @matthew-brett @reuning